### PR TITLE
Feat : 채팅 페이지 및 기획에 맞게 접근 및 정보 확인 가능 하게 채팅 로직 구현

### DIFF
--- a/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
@@ -1,0 +1,43 @@
+'use client';
+
+import React, { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { createClient } from '@/utils/supabase/client';
+import Chat from '@/components/Chat';
+
+const ChatPage = () => {
+  const { id: senderId, receiverid } = useParams() as { id: string; receiverid: string };
+  const router = useRouter();
+  const supabase = createClient();
+
+  const handleBack = () => {
+    router.back();
+  };
+
+  const checkAccess = async () => {
+    const { data, error } = await supabase.auth.getUser();
+
+    if (error) throw new Error(error.message);
+
+    if (data.user.id !== senderId && data.user.id !== receiverid) {
+      alert('접근 권한이 없습니다.');
+      router.push('/');
+    }
+  };
+
+  useEffect(() => {
+    checkAccess();
+  }, [senderId, receiverid, router, supabase]);
+
+  return (
+    <div>
+      <div className="mb-4 flex justify-around">
+        <button onClick={handleBack}>Go Back</button>
+        <p className="font-bold">message</p>
+      </div>
+      <Chat senderId={senderId} receiverId={receiverid} />
+    </div>
+  );
+};
+
+export default ChatPage;

--- a/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
@@ -1,12 +1,14 @@
 'use client';
 
 import React, { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import { useParams, useRouter, useSearchParams } from 'next/navigation';
+import Image from 'next/image';
 import { createClient } from '@/utils/supabase/client';
 import Chat from '@/components/Chat';
 
 const ChatPage = () => {
   const { id: senderId, receiverid } = useParams() as { id: string; receiverid: string };
+  const searchParams = useSearchParams();
   const router = useRouter();
   const supabase = createClient();
 
@@ -29,11 +31,24 @@ const ChatPage = () => {
     checkAccess();
   }, [senderId, receiverid, router, supabase]);
 
+  const postTitle = searchParams.get('postTitle') || '제목 없음';
+  const postImage = searchParams.get('postImage') || '';
+
   return (
     <div>
       <div className="mb-4 flex justify-around">
         <button onClick={handleBack}>Go Back</button>
         <p className="font-bold">message</p>
+      </div>
+      <div className="flex">
+        <Image
+          className="mb-[20px] mr-2"
+          src={postImage ?? '/icons/upload.png'}
+          alt={postTitle ?? 'Default title'}
+          width={40}
+          height={40}
+        />
+        <p className="text-[14px] font-bold">Title: {postTitle}</p>
       </div>
       <Chat senderId={senderId} receiverId={receiverid} />
     </div>

--- a/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/[receiverid]/chatpage/page.tsx
@@ -7,7 +7,7 @@ import { createClient } from '@/utils/supabase/client';
 import Chat from '@/components/Chat';
 
 const ChatPage = () => {
-  const { id: senderId, receiverid } = useParams() as { id: string; receiverid: string };
+  const { id: senderId, receiverid: receiverId } = useParams() as { id: string; receiverid: string };
   const searchParams = useSearchParams();
   const router = useRouter();
   const supabase = createClient();
@@ -21,7 +21,7 @@ const ChatPage = () => {
 
     if (error) throw new Error(error.message);
 
-    if (data.user.id !== senderId && data.user.id !== receiverid) {
+    if (data.user.id !== senderId && data.user.id !== receiverId) {
       alert('접근 권한이 없습니다.');
       router.push('/');
     }
@@ -29,10 +29,11 @@ const ChatPage = () => {
 
   useEffect(() => {
     checkAccess();
-  }, [senderId, receiverid, router, supabase]);
+  }, [senderId, receiverId, router, supabase]);
 
-  const postTitle = searchParams.get('postTitle') || '제목 없음';
-  const postImage = searchParams.get('postImage') || '';
+  const postId = searchParams.get('postId');
+  const postTitle = searchParams.get('postTitle');
+  const postImage = searchParams.get('postImage');
 
   return (
     <div>
@@ -50,7 +51,7 @@ const ChatPage = () => {
         />
         <p className="text-[14px] font-bold">Title: {postTitle}</p>
       </div>
-      <Chat senderId={senderId} receiverId={receiverid} />
+      <Chat postId={postId || ''} senderId={senderId} receiverId={receiverId} />
     </div>
   );
 };

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
@@ -4,44 +4,95 @@ import React from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
-import { API_MYPAGE_CHATS } from '@/utils/apiConstants';
+import { API_MYPAGE_CHATS, API_POST_DETAILS } from '@/utils/apiConstants';
 
 type ChatListProps = {
   userId: string;
 };
 
+type Chat = {
+  post_id: string;
+  receiver_id: string;
+  content: string;
+  created_at: string;
+};
+
+type Post = {
+  id: string;
+  title: string;
+  image: string;
+};
+
 const ChatList = ({ userId }: ChatListProps) => {
   const router = useRouter();
 
-  const { data, error, isLoading } = useQuery({
+  const fetchPostDetails = async (postId: string): Promise<Post> => {
+    const response = await fetch(API_POST_DETAILS(postId));
+    if (!response.ok) throw new Error('Failed to fetch post details');
+    return response.json();
+  };
+
+  const {
+    data: chatData,
+    error: chatError,
+    isLoading: chatLoading
+  } = useQuery<Chat[]>({
     queryKey: ['chatList', userId],
     queryFn: async () => {
       const response = await fetch(API_MYPAGE_CHATS(userId));
-
       if (!response.ok) throw new Error('Failed to fetch chat list');
-
       return response.json();
     }
   });
 
-  if (isLoading) return <div>Loading...</div>;
-  if (error) return <div>Error loading chats</div>;
+  const postIds = chatData?.map((chat) => chat.post_id) || [];
+
+  const {
+    data: postData,
+    error: postError,
+    isLoading: postLoading
+  } = useQuery<Post[]>({
+    queryKey: ['postDetails', postIds],
+    queryFn: async () => {
+      const postDetails = await Promise.all(postIds.map((postId) => fetchPostDetails(postId)));
+      return postDetails;
+    },
+    enabled: postIds.length > 0
+  });
+
+  if (chatLoading || postLoading) return <div>Loading...</div>;
+  if (chatError || postError) return <div>Error loading data</div>;
 
   return (
     <div>
-      {data?.map((chat: any, index: number) => (
-        <div
-          key={index}
-          onClick={() =>
-            router.push(
-              `/${userId}/${chat.receiver_id}/chatpage?postTitle=${chat.postTitle}&postImage=${chat.postImage}`
-            )
-          }
-        >
-          <p>{chat.content}</p>
-          <p>{new Date(chat.created_at).toLocaleString()}</p>
-        </div>
-      ))}
+      {chatData?.map((chat: Chat, index: number) => {
+        const postDetails = postData?.find((post) => post.id === chat.post_id);
+
+        return (
+          <div
+            key={index}
+            onClick={() =>
+              router.push(
+                `/${userId}/${chat.receiver_id}/chatpage?postId=${chat.post_id}&postTitle=${postDetails?.title}&postImage=${postDetails?.image}`
+              )
+            }
+          >
+            {postDetails && (
+              <div>
+                <p>{postDetails.title}</p>
+                <Image
+                  src={postDetails.image ?? '/icons/upload.png'}
+                  alt={postDetails.title ?? 'Default title'}
+                  width={40}
+                  height={40}
+                />
+              </div>
+            )}
+            <p>{chat.content}</p>
+            <p>{new Date(chat.created_at).toLocaleString()}</p>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import React from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+import Image from 'next/image';
+import { API_MYPAGE_CHATS } from '@/utils/apiConstants';
+
+type ChatListProps = {
+  userId: string;
+};
+
+const ChatList = ({ userId }: ChatListProps) => {
+  const router = useRouter();
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ['chatList', userId],
+    queryFn: async () => {
+      const response = await fetch(API_MYPAGE_CHATS(userId));
+
+      if (!response.ok) throw new Error('Failed to fetch chat list');
+
+      return response.json();
+    }
+  });
+
+  if (isLoading) return <div>Loading...</div>;
+  if (error) return <div>Error loading chats</div>;
+
+  return (
+    <div>
+      {data?.map((chat: any, index: number) => (
+        <div
+          key={index}
+          onClick={() =>
+            router.push(
+              `/${userId}/${chat.receiver_id}/chatpage?postTitle=${chat.postTitle}&postImage=${chat.postImage}`
+            )
+          }
+        >
+          <p>{chat.content}</p>
+          <p>{new Date(chat.created_at).toLocaleString()}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default ChatList;

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
@@ -78,14 +78,15 @@ const ChatList = ({ userId }: ChatListProps) => {
             }
           >
             {postDetails && (
-              <div>
-                <p>{postDetails.title}</p>
+              <div className="flex">
                 <Image
+                  className="mr-4"
                   src={postDetails.image ?? '/icons/upload.png'}
                   alt={postDetails.title ?? 'Default title'}
                   width={40}
                   height={40}
                 />
+                <p>{postDetails.title}</p>
               </div>
             )}
             <p>{chat.content}</p>

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/_components/ChatList.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useRouter } from 'next/navigation';
 import Image from 'next/image';
 import { API_MYPAGE_CHATS, API_POST_DETAILS } from '@/utils/apiConstants';
+import axios from 'axios';
 
 type ChatListProps = {
   userId: string;
@@ -27,9 +28,9 @@ const ChatList = ({ userId }: ChatListProps) => {
   const router = useRouter();
 
   const fetchPostDetails = async (postId: string): Promise<Post> => {
-    const response = await fetch(API_POST_DETAILS(postId));
-    if (!response.ok) throw new Error('Failed to fetch post details');
-    return response.json();
+    const response = await axios.get(API_POST_DETAILS(postId));
+
+    return response.data;
   };
 
   const {
@@ -39,9 +40,9 @@ const ChatList = ({ userId }: ChatListProps) => {
   } = useQuery<Chat[]>({
     queryKey: ['chatList', userId],
     queryFn: async () => {
-      const response = await fetch(API_MYPAGE_CHATS(userId));
-      if (!response.ok) throw new Error('Failed to fetch chat list');
-      return response.json();
+      const response = await axios.get(API_MYPAGE_CHATS(userId));
+
+      return response.data;
     }
   });
 

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/page.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/page.tsx
@@ -8,6 +8,7 @@ import ProfileView from './_components/ProfileView';
 import ReviewList from './_components/ReviewList';
 import LikeList from './_components/LikeList';
 import ReservationList from './_components/ReservationList';
+import ChatList from './_components/ChatList';
 
 const MyPage = () => {
   const { id } = useParams() as { id: string };
@@ -33,6 +34,9 @@ const MyPage = () => {
       {selectedComponent === 'posts' && <PostList />}
       {selectedComponent === 'Reservations' && <ReservationList />}
       {selectedComponent === 'reviews' && <ReviewList userId={id} />}
+      <div>
+        <ChatList userId={id} />
+      </div>
     </div>
   );
 };

--- a/src/app/(providers)/(root)/(mypage)/[id]/mypage/page.tsx
+++ b/src/app/(providers)/(root)/(mypage)/[id]/mypage/page.tsx
@@ -18,13 +18,9 @@ const MyPage = () => {
     router.back();
   };
 
-  const senderId = id;
-  const receiverId = 'b83f8bba-9072-44a2-9dd8-122cbc06fff8';
-
   return (
     <div>
       <h1 className="mb-4">My Page</h1>
-      <Chat senderId={senderId} receiverId={receiverId} />
       <button onClick={handleBack}>Go Back</button>
       <ProfileView userId={id} />
       <div className="mb-2 mt-4 flex justify-around">

--- a/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
+++ b/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
@@ -88,7 +88,6 @@ export const Guide = () => {
     const receiverId = user.id;
 
     const query = new URLSearchParams({
-      postId,
       postTitle: post.title,
       postImage: post.image
     }).toString();

--- a/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
+++ b/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
@@ -3,16 +3,23 @@
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import Image from 'next/image';
-import { useParams } from 'next/navigation';
-import React from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import React, { useEffect, useState } from 'react';
+import { createClient } from '@/utils/supabase/client';
+import { API_MYPAGE_PROFILE } from '@/utils/apiConstants';
 
 interface User {
   name: string;
   avatar: string;
+  id: string;
+  region: string;
 }
 
 export const Guide = () => {
   const { id: postId } = useParams() as { id: string };
+  const supabase = createClient();
+  const router = useRouter();
+  const [customerUser, setCustomerUser] = useState<User | null>(null);
 
   // 작성자 데이터를 가져오는 함수
   const fetchUser = async (): Promise<User> => {
@@ -30,7 +37,44 @@ export const Guide = () => {
     enabled: !!postId
   });
 
+  const fetchCustomerUser = async () => {
+    const { data, error } = await supabase.auth.getUser();
+
+    if (error) throw new Error(error.message);
+
+    if (data.user) {
+      const userId = data.user.id;
+      const response = await axios.get(API_MYPAGE_PROFILE(userId));
+      const profileData = response.data;
+
+      const customerUserData: User = {
+        id: profileData.id,
+        name: profileData.name,
+        avatar: profileData.avatar,
+        region: profileData.region
+      };
+
+      setCustomerUser(customerUserData);
+    }
+  };
+
+  const handleChat = () => {
+    if (!customerUser && !user) throw new Error('Customer user or guide user is missing.');
+
+    if (customerUser && user) {
+      const senderId = customerUser.id;
+      const receiverId = user.id;
+
+      router.push(`/${senderId}/${receiverId}/chatpage`);
+    }
+  };
+
+  useEffect(() => {
+    fetchCustomerUser();
+  }, [supabase]);
+
   if (isPending) return <div>Loading...</div>;
+
   if (error) return <div>Error fetching user data</div>;
 
   return (
@@ -46,12 +90,15 @@ export const Guide = () => {
               height={96}
               className="mr-2 h-24 w-24 rounded-full object-cover"
             />
+            <p>{user.region}</p>
             <h4>{user.name}</h4>
             <h5>투어 지역은 보류</h5>
+            <button className="mb-6 border" onClick={handleChat}>
+              메시지 보내기
+            </button>
           </>
         )}
       </div>
-      <button className="mb-6 border">메시지 보내기</button>
     </div>
   );
 };

--- a/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
+++ b/src/app/(providers)/(root)/detail/[id]/_components/Guide.tsx
@@ -88,6 +88,7 @@ export const Guide = () => {
     const receiverId = user.id;
 
     const query = new URLSearchParams({
+      postId: post.id,
       postTitle: post.title,
       postImage: post.image
     }).toString();

--- a/src/app/api/detail/guide/[id]/route.ts
+++ b/src/app/api/detail/guide/[id]/route.ts
@@ -17,7 +17,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
     // user_id를 통해 작성자 정보를 가져옴
     const { data: user, error: userError } = await supabase
       .from('users')
-      .select('name, avatar')
+      .select('id, name, avatar, region')
       .eq('id', post.user_id)
       .single();
 

--- a/src/app/api/mypage/[id]/chatpost/route.ts
+++ b/src/app/api/mypage/[id]/chatpost/route.ts
@@ -1,0 +1,19 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createClient();
+  const { id: postId } = params;
+
+  try {
+    const { data: post, error } = await supabase.from('posts').select('*').eq('id', postId).single();
+    if (error) {
+      console.error('Error fetching post:', error.message);
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+    return NextResponse.json(post, { status: 200 });
+  } catch (error) {
+    console.error('Unexpected server error:', error);
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/mypage/[id]/chatpost/route.ts
+++ b/src/app/api/mypage/[id]/chatpost/route.ts
@@ -8,12 +8,11 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { data: post, error } = await supabase.from('posts').select('*').eq('id', postId).single();
     if (error) {
-      console.error('Error fetching post:', error.message);
       return NextResponse.json({ error: error.message }, { status: 500 });
     }
+
     return NextResponse.json(post, { status: 200 });
   } catch (error) {
-    console.error('Unexpected server error:', error);
     return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
   }
 }

--- a/src/app/api/mypage/[id]/chats/route.ts
+++ b/src/app/api/mypage/[id]/chats/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/utils/supabase/server';
+
+export async function GET(request: NextRequest, { params }: { params: { id: string } }) {
+  const supabase = createClient();
+  const { id: userId } = params;
+
+  try {
+    const { data, error } = await supabase
+      .from('messages')
+      .select('sender_id, receiver_id, content, created_at')
+      .or(`sender_id.eq.${userId},receiver_id.eq.${userId}`)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return NextResponse.json({ error: error.message }, { status: 500 });
+    }
+
+    const chatList: any[] = [];
+    const chatSet = new Set();
+
+    data.forEach((message) => {
+      const chatId = message.sender_id === userId ? message.receiver_id : message.sender_id;
+
+      if (!chatSet.has(chatId)) {
+        chatSet.add(chatId);
+        chatList.push(message);
+      }
+    });
+
+    return NextResponse.json(chatList, { status: 200 });
+  } catch (error) {
+    return NextResponse.json({ error: 'Internal Server Error' }, { status: 500 });
+  }
+}

--- a/src/app/api/mypage/[id]/chats/route.ts
+++ b/src/app/api/mypage/[id]/chats/route.ts
@@ -8,7 +8,7 @@ export async function GET(request: NextRequest, { params }: { params: { id: stri
   try {
     const { data, error } = await supabase
       .from('messages')
-      .select('sender_id, receiver_id, content, created_at')
+      .select('sender_id, receiver_id, content, created_at, post_id')
       .or(`sender_id.eq.${userId},receiver_id.eq.${userId}`)
       .order('created_at', { ascending: false });
 

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -37,16 +37,22 @@ const Chat: React.FC<ChatProps> = ({ senderId, receiverId }) => {
   };
 
   return (
-    <div className="flex h-screen flex-col border border-gray-300">
-      <div className="flex-1 overflow-y-auto p-4">
+    <div className="flex h-screen max-w-[360px] flex-col border border-gray-300 text-[14px]">
+      <div className="overflow-y-auto p-4">
         {messages.map((msg) => (
           <div
             key={msg.id}
-            className={`mb-2 rounded p-2 ${
-              msg.sender_id === senderId ? 'self-end bg-green-200' : 'self-start bg-white'
-            }`}
+            className={`mb-10 flex flex-col ${msg.sender_id === senderId ? 'items-end' : 'items-start'}`}
           >
-            {msg.content}
+            {msg.sender_id !== senderId && <p className="mr-2 text-sm font-bold">{msg.sender_id}</p>}
+            <div
+              className={`w-[240px] break-all rounded p-2 ${msg.sender_id === senderId ? 'bg-green-200' : 'bg-gray-200'}`}
+            >
+              <p>{msg.content}</p>
+            </div>
+            <p className={` ${msg.sender_id === senderId ? 'right-0' : 'left-0'} mt-2 text-[10px] text-gray-500`}>
+              {msg.created_at}
+            </p>
           </div>
         ))}
       </div>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -7,14 +7,16 @@ type Message = {
   receiver_id: string;
   content: string;
   created_at: string;
+  post_id: string;
 };
 
 type ChatProps = {
   senderId: string;
   receiverId: string;
+  postId: string;
 };
 
-const Chat: React.FC<ChatProps> = ({ senderId, receiverId }) => {
+const Chat: React.FC<ChatProps> = ({ senderId, receiverId, postId }) => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [newMessage, setNewMessage] = useState<string>('');
 
@@ -29,7 +31,7 @@ const Chat: React.FC<ChatProps> = ({ senderId, receiverId }) => {
 
   const handleSend = async () => {
     if (newMessage.trim()) {
-      await sendMessage(senderId, receiverId, newMessage);
+      await sendMessage(senderId, receiverId, newMessage, postId);
       setNewMessage('');
       const fetchedMessages = await fetchMessages(senderId, receiverId);
       setMessages(fetchedMessages);

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -46,12 +46,12 @@ const Chat: React.FC<ChatProps> = ({ senderId, receiverId }) => {
           >
             {msg.sender_id !== senderId && <p className="mr-2 text-sm font-bold">{msg.sender_id}</p>}
             <div
-              className={`w-[240px] break-all rounded p-2 ${msg.sender_id === senderId ? 'bg-green-200' : 'bg-gray-200'}`}
+              className={`max-w-[240px] break-all rounded p-2 ${msg.sender_id === senderId ? 'bg-green-200' : 'bg-gray-200'}`}
             >
               <p>{msg.content}</p>
             </div>
             <p className={` ${msg.sender_id === senderId ? 'right-0' : 'left-0'} mt-2 text-[10px] text-gray-500`}>
-              {msg.created_at}
+              {new Date(msg.created_at).toLocaleString()}
             </p>
           </div>
         ))}

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -24,7 +24,7 @@ const Chat: React.FC<ChatProps> = ({ senderId, receiverId, postId }) => {
     const interval = setInterval(async () => {
       const fetchedMessages = await fetchMessages(senderId, receiverId);
       setMessages(fetchedMessages);
-    }, 3000);
+    }, 1000);
 
     return () => clearInterval(interval);
   }, [senderId, receiverId]);

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -12,7 +12,6 @@ export const fetchMessages = async (senderId: string, receiverId: string) => {
     .order('created_at', { ascending: true });
 
   if (error) {
-    console.error(error);
     return [];
   }
 
@@ -25,7 +24,6 @@ export const sendMessage = async (senderId: string, receiverId: string, content:
     .insert([{ sender_id: senderId, receiver_id: receiverId, content, post_id: postId }]);
 
   if (error) {
-    console.error(error);
     return null;
   }
 

--- a/src/services/chatService.ts
+++ b/src/services/chatService.ts
@@ -19,10 +19,10 @@ export const fetchMessages = async (senderId: string, receiverId: string) => {
   return data;
 };
 
-export const sendMessage = async (senderId: string, receiverId: string, content: string) => {
+export const sendMessage = async (senderId: string, receiverId: string, content: string, postId: string) => {
   const { data, error } = await supabase
     .from('messages')
-    .insert([{ sender_id: senderId, receiver_id: receiverId, content }]);
+    .insert([{ sender_id: senderId, receiver_id: receiverId, content, post_id: postId }]);
 
   if (error) {
     console.error(error);

--- a/src/utils/apiConstants.ts
+++ b/src/utils/apiConstants.ts
@@ -3,3 +3,5 @@ export const API_MYPAGE_PROFILE_PASSWORD = (userId: string) => `/api/mypage/${us
 export const API_MYPAGE_LIKES = (userId: string) => `/api/mypage/${userId}/profile/postlikes`;
 export const API_MYPAGE_POST = (postId: string) => `/api/post`;
 export const API_MYPAGE_REVIEWS = (userId: string) => `/api/mypage/${userId}/reviews`;
+
+export const API_POST_DETAILS = (postId: string) => `/api/mypage/${postId}/chatpost`;

--- a/src/utils/apiConstants.ts
+++ b/src/utils/apiConstants.ts
@@ -3,5 +3,6 @@ export const API_MYPAGE_PROFILE_PASSWORD = (userId: string) => `/api/mypage/${us
 export const API_MYPAGE_LIKES = (userId: string) => `/api/mypage/${userId}/profile/postlikes`;
 export const API_MYPAGE_POST = (postId: string) => `/api/post`;
 export const API_MYPAGE_REVIEWS = (userId: string) => `/api/mypage/${userId}/reviews`;
+export const API_MYPAGE_CHATS = (userId: string) => `/api/mypage/${userId}/chats`;
 
 export const API_POST_DETAILS = (postId: string) => `/api/mypage/${postId}/chatpost`;

--- a/yarn.lock
+++ b/yarn.lock
@@ -245,6 +245,11 @@
   resolved "https://registry.yarnpkg.com/@pkgr/core/-/core-0.1.1.tgz#1ec17e2edbec25c8306d424ecfbf13c7de1aaa31"
   integrity sha512-cq8o4cWH0ibXh9VGi5P20Tu9XF/0fFXl9EUinr9QfTM7a7p0oTA4iJRCQWppXR1Pg8dSM0UCItCkPwsk9qWWYA==
 
+"@portone/browser-sdk@^0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@portone/browser-sdk/-/browser-sdk-0.0.1.tgz#252bd05ac47176dd09ad4e5ad0d4363bc0619c0a"
+  integrity sha512-33K4PB5gdzMCv1sgfgxls2reg3O/znWxELb22zlh4Df/vhhmn64UWyvXB7Zx+mLsihQZCwS9+LVo7AW6UkactA==
+
 "@portone/browser-sdk@^0.0.8":
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/@portone/browser-sdk/-/browser-sdk-0.0.8.tgz#660692320ab4a517c4fb4f37a39b58ef186be836"
@@ -2901,16 +2906,7 @@ streamsearch@^1.1.0:
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-1.1.0.tgz#404dd1e2247ca94af554e841a8ef0eaa238da764"
   integrity sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -2990,14 +2986,7 @@ string.prototype.trimstart@^1.0.8:
     define-properties "^1.2.1"
     es-object-atoms "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
작업 페이지

- 마이페이지 , 채팅페이지 , 투어 상세페이지

작업내용
- 채팅리스트를 임시로 마이페이지 내에 구현 , 투어 정보와 마지막 메시지 및 시각 확인 가능 -> 클릭 시 채팅 페이지로 이동
- 채팅 페이지에서는 해당 투어 정보 확인과 함께 작성자와 채팅 가능
- 상세페이지에서 가이드에게 메시지 보내기를 누르면 위와 같이 동작

검토 사항

- 실시간 채팅 및 채팅 관련 확인이 필요
- 관련된 api 및 page에 최대한 수정,삭제를 줄이고 추가만 하는 방식으로 접근 -> 수정이 어느정도 필요한 api는 혹시 몰라 우선 그냥 새로 만들어서 사용했으므로 합병 여부도 확인 필요
- 다양한 코드들이 비슷하게 사용됨에따라 코드 작성 방식도 유지보수의 효율을 위해 리팩토링 검토 필요
- 리스트 ui 관련해서 어떤식으로 분류할지 결정 필요

기술적 의사 결정

- 채팅 관련 정보를 테이블에 저장하여 정보를 가져오는데 게시글 정보url을 params로 넘겨주고 그 값을 db에서 비교하여 페이지가 출력 -> params로인해 url에 정보가 남으므로 개선이 필요해보임 , 우선 유저id로 접근은 안되게 해보았으나 확인 필요 ( 회원가입이 일시적 오류인지 모르겠으나 안됨에따라 확인을 못 했음 )